### PR TITLE
Change logic around installation of smbfs package

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
 maintainer        "Flyte"
 maintainer_email  "autofs-github@failcode.co.uk"
 description       "Configures the automount daemon"
-version           "0.2.2"
+version           "0.2.3"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,9 @@
 #
 
 package "autofs"
-package "smbfs"
+
+# Install smbfs package, unless we are on ubuntu 13.x
+package platform?("ubuntu") && node['platform_version'].to_f >= 12.10 ? "cifs-utils" : "smbfs"
 
 service "autofs" do
 	supports [ :start, :stop, :restart, :reload, :status ]


### PR DESCRIPTION
On Ubuntu 13.x the package "smbfs" no longer exists.
This change installs the package "cfis-utils" instead for Ubuntu 13.x.
