### PR TITLE
metadata.rb: Add name attribute to metadata to support Chef v12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name		  "autofs"
 maintainer        "Flyte"
 maintainer_email  "autofs-github@failcode.co.uk"
 description       "Configures the automount daemon"


### PR DESCRIPTION
I have added a new `name` attribute to the metadata.rb which is a requirement when using chef-client v12.
